### PR TITLE
Fix Travis CI build after adding bcrypt to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,12 @@ cache:
   directories:
     - node_modules # NPM packages
 script: npm run lint
+# To be able to build bcrypt and other modules which may depend on C++/C++-11
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
Travis CI was failing because it is a C++ module and therefore needs C++ installed in the dependencies which was not the case earlier. Hence the build was failing.

https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
